### PR TITLE
Allow repoversion-content uniquness constraints

### DIFF
--- a/pulpcore/plugin/stages/__init__.py
+++ b/pulpcore/plugin/stages/__init__.py
@@ -1,6 +1,10 @@
 from .api import create_pipeline, EndStage, Stage  # noqa
 from .artifact_stages import ArtifactDownloader, ArtifactSaver, QueryExistingArtifacts  # noqa
-from .association_stages import ContentUnitAssociation, ContentUnitUnassociation  # noqa
+from .association_stages import (  # noqa
+    ContentUnitAssociation,
+    ContentUnitUnassociation,
+    RemoveDuplicates
+)
 from .content_unit_stages import ContentUnitSaver, QueryExistingContentUnits  # noqa
 from .declarative_version import DeclarativeVersion  # noqa
 from .models import DeclarativeArtifact, DeclarativeContent  # noqa


### PR DESCRIPTION
Some plugins have uniqueness constraints for what content may be in the
same repository version. This new stage enables the DeclarativeVersion
to remove content to make room for incoming content.

https://pulp.plan.io/issues/3934
fixes #3934