### PR TITLE
Add the Handler and aiohttp.web.Application to API

### DIFF
--- a/pulpcore/plugin/content.py
+++ b/pulpcore/plugin/content.py
@@ -1,0 +1,2 @@
+from pulpcore.content import app  # noqa
+from pulpcore.content.handler import Handler  # noqa


### PR DESCRIPTION
Plugin writers need to be able to subclass-to-customize the Handler we
use. They also need to access the app instance users will configure to
run so plugin URLs can be served.

https://pulp.plan.io/issues/4273
closes #4273
