### PR TITLE
Rename connection_limit to download_concurrency

### DIFF
--- a/pulpcore/plugin/download/factory.py
+++ b/pulpcore/plugin/download/factory.py
@@ -64,7 +64,7 @@ class DownloaderFactory:
         self._handler_map = {'https': self._http_or_https, 'http': self._http_or_https,
                              'file': self._generic}
         self._session = self._make_aiohttp_session_from_remote()
-        self._semaphore = asyncio.Semaphore(value=remote.connection_limit)
+        self._semaphore = asyncio.Semaphore(value=remote.download_concurrency)
         atexit.register(self._session.close)
 
     def _make_aiohttp_session_from_remote(self):

--- a/pulpcore/plugin/stages/artifact_stages.py
+++ b/pulpcore/plugin/stages/artifact_stages.py
@@ -225,7 +225,7 @@ class ArtifactDownloader(Stage):
     downloads completed. Since it's a stream the total count isn't known until it's finished.
 
     This stage drains all available items from `in_q` and starts as many downloaders as possible
-    (up to `connection_limit` set on a Remote)
+    (up to `download_concurrency` set on a Remote)
 
     Args:
         max_concurrent_content (int): The maximum number of


### PR DESCRIPTION
Rename the 'connection_limit' to 'download_concurrency'
throughout the codebase and comments in the codebase to
variable name to be more understandable.

closes: #4114
https://pulp.plan.io/issues/4114

Signed-off-by: Pavel Picka <ppicka@redhat.com>