### PR TITLE
Add PathNotResolved exception from content app to plugin API

### DIFF
--- a/pulpcore/plugin/content.py
+++ b/pulpcore/plugin/content.py
@@ -1,2 +1,2 @@
 from pulpcore.content import app  # noqa
-from pulpcore.content.handler import Handler  # noqa
+from pulpcore.content.handler import Handler, PathNotResolved  # noqa


### PR DESCRIPTION
Derived content handlers may want to use the exception (e.g in live APIs).

ref #4273
https://pulp.plan.io/issues/4273
