### PR TITLE
Remove pk if IntegriyError is raised

### DIFF
--- a/pulpcore/plugin/stages/content_unit_stages.py
+++ b/pulpcore/plugin/stages/content_unit_stages.py
@@ -116,6 +116,7 @@ class ContentUnitSaver(Stage):
                             with transaction.atomic():
                                 declarative_content.content.save()
                         except IntegrityError:
+                            declarative_content.content.pk = None
                             declarative_content.content = \
                                 declarative_content.content.__class__.objects.get(
                                     declarative_content.content.q())


### PR DESCRIPTION
If the pk is still set, then the declarative_content.content.q() will
attempt to use the pk to find the duplicate object. Since the object was
not saved to the db, this will raise an IntegrityError that is not
handled. By setting pk to None, q() will instead query by the natural
key, which will find the dupe.

[noissue]