### PR TITLE
The get_future() method is missing in the docs

### DIFF
--- a/docs/api-reference/stages.rst
+++ b/docs/api-reference/stages.rst
@@ -24,6 +24,7 @@ DeclarativeVersion
 
 .. autoclass:: pulpcore.plugin.stages.DeclarativeContent
    :no-members:
+   :members: get_future
 
 
 .. _stages-api:


### PR DESCRIPTION
[noissue]
