### PR TITLE
Troubleshooting support; docstrings. [noissue]

### DIFF
--- a/pulpcore/plugin/stages/models.py
+++ b/pulpcore/plugin/stages/models.py
@@ -127,3 +127,6 @@ class DeclarativeContent:
             # If on 3.7, we could preferrably use get_running_loop()
             self.future = asyncio.get_event_loop().create_future()
         return self.future
+
+    def __str__(self):
+        return str(self.content.__class__.__name__)


### PR DESCRIPTION
Adds missing docstring on `_connect()`.

Although, the log statements really helped with troubleshooting the docker plugin I'm not convinced that they are a worth-while addition.  Thoughts?

Preventing `Stage.put()` of `None` will prevent plugin writers from accidentally doing it.  I burned a good bit of time troubleshooting this because it just causes the pipeline to stall.  Same for the duplicate stage check in `create_pipeline()`.