### PR TITLE
Version bump for beta 19

### DIFF
--- a/docs/release-notes/index.rst
+++ b/docs/release-notes/index.rst
@@ -10,6 +10,11 @@ The Plugin API currently supports version 3.y of Pulp Core.
 See :doc:`Plugin API <../index>` and
 :doc:`Plugin Development <../plugin-writer/index>`.
 
+0.1.0b19
+========
+
+* `List of plugin API related changes in beta 19 <https://github.com/pulp/pulpcore-plugin/pulls?utf8=%E2%9C%93&q=is%3Aclosed+merged%3A2019-02-14T15%3A30%3A00-06%3A00..2019-02-05T17%3A00%3A00-06%3A00+>`_
+
 0.1.0b18
 ========
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 requirements = [
-    'pulpcore>=3.0.0b19',
+    'pulpcore>=3.0.0b20',
     'aiohttp',
     'aiofiles',
     'backoff',
@@ -14,7 +14,7 @@ setup(
     name='pulpcore-plugin',
     description='Pulp Plugin API',
     long_description=long_description,
-    version='0.1.0b18',
+    version='0.1.0b19',
     license='GPLv2+',
     packages=find_packages(exclude=['test']),
     author='Pulp Team',


### PR DESCRIPTION
Beta 18 was broken because it depended on pulpcore beta 19. Beta 20 is needed.

[noissue]