### PR TITLE
Prevent content with future to deadlock

### DIFF
--- a/pulpcore/plugin/stages/api.py
+++ b/pulpcore/plugin/stages/api.py
@@ -108,14 +108,18 @@ class Stage:
         """
         batch = []
         shutdown = False
+        no_block = False
 
         def add_to_batch(content):
             nonlocal batch
             nonlocal shutdown
+            nonlocal no_block
             if content is None:
                 shutdown = True
                 log.debug(_('%(name)s - shutdown.'), {'name': self})
             else:
+                if not content.does_batch:
+                    no_block = True
                 batch.append(content)
 
         while not shutdown:
@@ -129,7 +133,7 @@ class Stage:
                 else:
                     add_to_batch(content)
 
-            if batch and (len(batch) >= minsize or shutdown):
+            if batch and (len(batch) >= minsize or shutdown or no_block):
                 log.debug(
                     _('%(name)s - next batch[%(length)d].'),
                     {
@@ -138,6 +142,7 @@ class Stage:
                     })
                 yield batch
                 batch = []
+                no_block = False
 
     async def put(self, item):
         """

--- a/pulpcore/plugin/stages/content_stages.py
+++ b/pulpcore/plugin/stages/content_stages.py
@@ -184,8 +184,8 @@ class ResolveContentFutures(Stage):
     different content type `Bar`. Consider this code in FirstStage::
 
         # Create d_content and d_artifact for a `foo_a`
-        foo_a = DeclarativeContent(...)
-        foo_a_future = foo_a.get_future()  # This is awaitable
+        foo_a = DeclarativeContent(..., does_batch=False)
+        foo_a_future = foo_a.get_or_create_future()  # This is awaitable
 
         ...
 

--- a/pulpcore/plugin/stages/models.py
+++ b/pulpcore/plugin/stages/models.py
@@ -95,6 +95,8 @@ class DeclarativeContent:
         d_artifacts (list): A list of zero or more
             :class:`~pulpcore.plugin.stages.DeclarativeArtifact` objects associated with `content`.
         extra_data (dict): A dictionary available for additional data to be stored in.
+        does_batch (bool): If `False`, prevent batching mechanism to block this item.
+            Defaults to `True`.
         future (:class:`~asyncio.Future`): A future that gets resolved to the
             :class:`~pulpcore.plugin.models.Content` in the
             :class:`~pulpcore.plugin.stages.ResolveContentFutures` stage. See the
@@ -104,20 +106,23 @@ class DeclarativeContent:
         ValueError: If `content` is not specified.
     """
 
-    __slots__ = ('content', 'd_artifacts', 'extra_data', 'future')
+    __slots__ = ('content', 'd_artifacts', 'extra_data', 'does_batch', 'future')
 
-    def __init__(self, content=None, d_artifacts=None, extra_data=None):
+    def __init__(self, content=None, d_artifacts=None, extra_data=None, does_batch=True):
         if not content:
             raise ValueError(_("DeclarativeContent must have a 'content'"))
         self.content = content
         self.d_artifacts = d_artifacts or []
         self.extra_data = extra_data or {}
+        self.does_batch = does_batch
         self.future = None
 
-    def get_future(self):
+    def get_or_create_future(self):
         """
         Return the existing or a new future.
 
+        If you rely on this future in a the course of the pipeline, consider clearing the
+        `does_batch` attribute to prevent deadlocks.
         See the :class:`~pulpcore.plugin.stages.ResolveContentFutures` stage for example usage.
 
         Returns:


### PR DESCRIPTION
DeclarativeContent with an attached future are meant to result in more
DeclarativeContent from the first stage. Therefore blocking them while
waiting for batches to fill, can result in deadlocks.

closes: #4296
https://pulp.plan.io/issues/4296