### PR TITLE
Revert "The get_future() method is missing in the docs"  [noissue]

### DIFF
--- a/docs/api-reference/stages.rst
+++ b/docs/api-reference/stages.rst
@@ -24,7 +24,6 @@ DeclarativeVersion
 
 .. autoclass:: pulpcore.plugin.stages.DeclarativeContent
    :no-members:
-   :members: get_future
 
 
 .. _stages-api:


### PR DESCRIPTION
Reverts pulp/pulpcore-plugin#45
[noissue]