### PR TITLE
get_future() removed; pipeline_stages() added. [noissue].

### DIFF
--- a/docs/api-reference/stages.rst
+++ b/docs/api-reference/stages.rst
@@ -24,7 +24,7 @@ DeclarativeVersion
 
 .. autoclass:: pulpcore.plugin.stages.DeclarativeContent
    :no-members:
-   :members: get_future
+   :members: pipeline_stages
 
 
 .. _stages-api:


### PR DESCRIPTION
Fix builder failure caused by #45 and adds missing `pipeline_stages()` method used by plugin writers.