### PR TITLE
Test building docs against PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,12 @@ python:
     - "3.6"
     - "3.7"
 env:
-  matrix:
-    - DJANGO_MAX=2.2.100 DB=postgres TEST=pulp
-    #- DJANGO_MAX=2.2.100 TEST=docs
+    - TEST=pulp
+    - TEST=docs
 matrix:
+  exclude:
+    - python: "3.6"
+      env: TEST=docs
   fast_finish: true
 addons:
     # postgres versions provided by el7 RHSCL (lowest supportable version)

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -2,8 +2,8 @@
 set -v
 
 # dev_requirements should not be needed for testing; don't install them to make sure
-pip install "Django<=$DJANGO_MAX"
 pip install -r test_requirements.txt
+pip install -r doc_requirements.txt
 
 export COMMIT_MSG=$(git show HEAD^2 -s)
 export PULP_PR_NUMBER=$(echo $COMMIT_MSG | grep -oP 'Required\ PR:\ https\:\/\/github\.com\/pulp\/pulp\/pull\/(\d+)' | awk -F'/' '{print $7}')


### PR DESCRIPTION
Note that I am not creating a separate job for testing the docs. We're
limited by the number of concurrent jobs in the Pulp org so I figure
it's more efficient to execute the docs check during the normal test
since it only adds 30-60 seconds.

fixes #4403
https://pulp.plan.io/issues/4403