### PR TITLE
Fix FileContent description in docs

### DIFF
--- a/docs/plugin-writer/concepts/subclassing/models.rst
+++ b/docs/plugin-writer/concepts/subclassing/models.rst
@@ -70,7 +70,7 @@ Adding to the simplified ``FileContent`` above:
         class FileContent(Content):
             """
             The "file" content type.
-            Content of this type represents a collection of 0 or more files uniquely
+            Content of this type represents a single file uniquely
             identified by path and SHA256 digest.
             Fields:
                 digest (str): The SHA256 HEX digest.
@@ -92,7 +92,7 @@ uniqueness, simply add other fields.
         class FileContent(Content):
             """
             The "file" content type.
-            Content of this type represents a collection of 0 or more files uniquely
+            Content of this type represents a single file uniquely
             identified by path and SHA256 digest.
             Fields:
                 relative_path (str): The file relative path.


### PR DESCRIPTION
File content is always 1 file.
Fixed in plugin-writer doc.

closes: #4372
https://pulp.plan.io/issues/4372

Required PR: https://github.com/pulp/pulp_file/pull/173

Signed-off-by: Pavel Picka <ppicka@redhat.com>
