### PR TITLE
Problem: plugin API missing pass-through cache interfaces

### DIFF
--- a/pulpcore/plugin/models/content.py
+++ b/pulpcore/plugin/models/content.py
@@ -29,3 +29,40 @@ class ContentGuard(models.ContentGuard):
             PermissionError: When not authorized.
         """
         raise NotImplementedError()
+
+
+class Content(models.Content):
+    """
+    A piece of managed content.
+
+    Relations:
+
+        _artifacts (models.ManyToManyField): Artifacts related to Content through ContentArtifact
+    """
+    class Meta:
+        abstract = True
+
+    @staticmethod
+    def init_from_artifact_and_relative_path(artifact, relative_path):
+        """
+        Return an instance of the specific content by inspecting an artifact.
+
+        Plugin writers are expected to override this method with an implementation for a specific
+        content type.
+
+        For example:
+            >>> if path.isabs(relative_path):
+            >>>     raise ValueError(_("Relative path can't start with '/'."))
+            >>> return FileContent(relative_path=relative_path, digest=artifact.sha256)
+
+        Args:
+            artifact (:class:`~pulpcore.plugin.models.Artifact`): An instance of an Artifact
+            relative_path (str): Relative path for the content
+
+        Raises:
+            ValueError: If relative_path starts with a '/'.
+
+        Returns:
+            An un-saved instance of :class:`~pulpcore.plugin.models.Content` sub-class.
+        """
+        raise NotImplementedError()

--- a/pulpcore/plugin/models/remote.py
+++ b/pulpcore/plugin/models/remote.py
@@ -1,4 +1,5 @@
 from gettext import gettext as _
+from os import path
 
 from pulpcore.app.models import Artifact as PlatformArtifact
 from pulpcore.app.models import Remote as PlatformRemote
@@ -85,3 +86,38 @@ class Remote(PlatformRemote):
             if remote_artifact.size:
                 kwargs['expected_size'] = remote_artifact.size
         return self.download_factory.build(url, **kwargs)
+
+    def get_remote_artifact_url(self, relative_path=None):
+        """
+        Get the full URL for a RemoteArtifact from a relative path.
+
+        This method returns the URL for a RemoteArtifact by concatinating the Remote's url and the
+        relative path.located in the Remote. Plugin writers are expected to override this method
+        when a more complex algorithm is needed to determine the full URL.
+
+        Args:
+            relative_path (str): The relative path of a RemoteArtifact
+
+        Raises:
+            ValueError: If relative_path starts with a '/'.
+
+        Returns:
+            str: A URL for a RemoteArtifact available at the Remote.
+        """
+        if path.isabs(relative_path):
+            raise ValueError(_("Relative path can't start with '/'. {0}").format(relative_path))
+        return path.join(self.url, relative_path)
+
+    def get_remote_artifact_content_type(self, relative_path=None):
+        """
+        Get the type of content that should be available at the relative path.
+
+        Plugin writers are expected to implement this method.
+
+        Args:
+            relative_path (str): The relative path of a RemoteArtifact
+
+        Returns:
+            Class: The Class of the content type that should be available at the relative path.
+        """
+        raise NotImplementedError()


### PR DESCRIPTION
Solution: add interfaces that enable pass-through cache for plugins

This patch extends the Remote API. It adds an interface for determining the full URL of a RemoteArtifact
by examining the relative path and the Remote's url. It also adds an interface for determining the type of
content that should be available at a relative path of a remote. These interfaces are used by the content
app when serving content in the pass-through cache mode. The content app needs to determine what URL is
actually being requested and what kind of content is being requested by the client.

This patch also extends the Content API. It adds a new constructor method to the Content model. This new
interface is a constructor that take an Artifact and a relative path to produce an unsaved instance of a
specific content type.

Plugin writers are expected to provide specific implementations of these methods.

re: #3894
https://pulp.plan.io/issues/3894