### PR TITLE
Problem: BaserDistributionSerializer not available in plugin API

### DIFF
--- a/pulpcore/plugin/serializers.py
+++ b/pulpcore/plugin/serializers.py
@@ -2,6 +2,7 @@
 from pulpcore.app.serializers import (  # noqa
     ArtifactSerializer,
     AsyncOperationResponseSerializer,
+    BaseDistributionSerializer,
     ContentGuardSerializer,
     NoArtifactContentSerializer,
     SingleArtifactContentSerializer,


### PR DESCRIPTION
Solution: Add BaseDistributionSerializer to the plugin API

re: #4435
https://pulp.plan.io/issues/4435
re: #4437
https://pulp.plan.io/issues/4437