### PR TITLE
Few unittests for plugin-api

### DIFF
--- a/pulpcore/tests/unit/models/test_content.py
+++ b/pulpcore/tests/unit/models/test_content.py
@@ -1,0 +1,43 @@
+import os
+import tempfile
+
+from django.test import TestCase
+from pulpcore.plugin.models import Artifact, Content, ContentArtifact
+
+
+class ContentCRUDTestCase(TestCase):
+
+    artifact01_path = os.path.join(tempfile.gettempdir(), 'artifact01-tmp')
+    artifact02_path = os.path.join(tempfile.gettempdir(), 'artifact02-tmp')
+
+    def setUp(self):
+        with open(self.artifact01_path, 'w') as f:
+            f.write('Temp Artifact File 01')
+        with open(self.artifact02_path, 'w') as f:
+            f.write('Temp Artifact File 02')
+        self.artifact01 = Artifact.init_and_validate(self.artifact01_path)
+        self.artifact01.save()
+        self.artifact02 = Artifact.init_and_validate(self.artifact02_path)
+        self.artifact02.save()
+
+    def test_create_and_read_content(self):
+        content = Content.objects.create()
+        content.save()
+        content_artifact = ContentArtifact.objects.create(
+            artifact=self.artifact01,
+            content=content,
+            relative_path=self.artifact01.file.path)
+        content_artifact.save()
+        self.assertTrue(
+            Content.objects.filter(pk=content.pk).exists()
+            and ContentArtifact.objects.get(
+                pk=content_artifact.pk
+            ).content.pk == Content.objects.get(pk=content.pk).pk
+        )
+
+    def test_remove_content(self):
+        content = Content.objects.create()
+        content.save()
+        # Assumes creation is tested by test_create_and_read_content function
+        Content.objects.filter(pk=content.pk).delete()
+        self.assertFalse(Content.objects.filter(pk=content.pk).exists())

--- a/pulpcore/tests/unit/models/test_repo_ver.py
+++ b/pulpcore/tests/unit/models/test_repo_ver.py
@@ -1,0 +1,47 @@
+from unittest.mock import patch
+from django.core.files.uploadedfile import SimpleUploadedFile
+
+from django.test import TestCase
+from pulpcore.plugin.models import Artifact, Content, ContentArtifact, Repository, RepositoryVersion
+from pulpcore.app.models.task import Task
+
+
+class PublisherCRUDTestCase(TestCase):
+
+    def setUp(self):
+        artifact = Artifact.objects.create(
+            md5="ec0df26316b1deb465d2d18af7b600f5",
+            sha1="cf6121b0425c2f2e3a2fcfe6f402d59730eb5661",
+            sha224="9a6297eb28d91fad5277c0833856031d0e940432ad807658bd2b60f4",
+            sha256="c8ddb3dcf8da48278d57b0b94486832c66a8835316ccf7ca39e143cbfeb9184f",
+            sha384=("53a8a0cebcb7780ed7624790c9d9a4d09ba74b47270d397f5ed7bc1c46777a0f"
+                    "be362aaf2bbe7f0966a350a12d76e28d"),
+            # noqa
+            sha512=("a94a65f19b864d184a2a5e07fa29766f08c6d49b6f624b3dd3a36a9826"
+                    "7b9137d9c35040b3e105448a869c23c2aec04c9e064e3555295c1b8de6515eed4da27d"),
+            # noqa
+            size=1024,
+            file=SimpleUploadedFile('test_filename', b'test content')
+        )
+        artifact.save()
+        self.content = Content.objects.create()
+        self.content.save()
+        self.content_artifact = ContentArtifact.objects.create(artifact=artifact,
+                                                               content=self.content,
+                                                               relative_path=artifact.file.path)
+        self.content_artifact.save()
+        self.repository = Repository.objects.create(name='foo')
+        self.repository.save()
+        self.task = Task.objects.create(state='Completed', name='test-task')
+        self.task.save()
+
+    @patch('pulpcore.app.models.task.get_current_job')
+    def test_create_repository_version(self, mock_task):
+        mock_task.return_value.id = self.task.pk
+        with RepositoryVersion.create(self.repository) as new_version:
+            new_version.add_content(Content.objects.filter(pk=self.content.pk))
+        self.assertTrue(RepositoryVersion.objects.filter().exists())
+
+    def test_remove_repository_version(self):
+        RepositoryVersion.objects.filter().delete()
+        self.assertFalse(RepositoryVersion.objects.filter().exists())


### PR DESCRIPTION
Adding unit tests for content and repository version models.

re: #4348
https://pulp.plan.io/issues/4348

Signed-off-by: Pavel Picka <ppicka@redhat.com>
