### PR TITLE
Keep _remote_artifact_saver_cas attr to handle cases when there is du…

### DIFF
--- a/pulpcore/plugin/stages/artifact_stages.py
+++ b/pulpcore/plugin/stages/artifact_stages.py
@@ -264,7 +264,6 @@ class RemoteArtifactSaver(Stage):
                 else:
                     remote_artifact = self._create_remote_artifact(d_artifact, content_artifact)
                     needed_ras.append(remote_artifact)
-            del d_content.content._remote_artifact_saver_cas
         return needed_ras
 
     @staticmethod


### PR DESCRIPTION
…p content in the batch.

[noissue]

There might be in one batch dup content where dc1.content == dc2.content.

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/en/3.0/nightly/contributing/pull-request-walkthrough.html
