### PR TITLE
Remove test dependency on psycopg2

### DIFF
--- a/doc_requirements.txt
+++ b/doc_requirements.txt
@@ -4,7 +4,6 @@ djangorestframework
 django-filter
 drf-nested-routers
 pyyaml
-psycopg2
 sphinx<1.8.0
 sphinx-rtd-theme
 sphinxcontrib-openapi


### PR DESCRIPTION
The tests don't need psycopg2.

https://pulp.plan.io/issues/4639
closes #4639
