### PR TITLE
Add release notes and version bump to rc2

### DIFF
--- a/docs/release-notes/index.rst
+++ b/docs/release-notes/index.rst
@@ -10,6 +10,20 @@ The Plugin API currently supports version 3.y of Pulp Core.
 See :doc:`Plugin API <../index>` and
 :doc:`Plugin Development <../plugin-writer/index>`.
 
+0.1.0rc2
+========
+
+* `List of plugin API related changes in rc 2 <https://github.com/pulp/pulpcore-plugin/compare/0.1.0rc1...0.1.0rc2>`_
+
+Breaking Changes
+----------------
+
+* `The RepositoryPublishURLSerializer was removed from the plugin API. <https://github.com/pulp/pulpcore-plugin/pull/93/>`_
+* `Publications are now Master/Detail. <https://pulp.plan.io/issues/4678>`_ Plugins that use
+  Publications will need to provide a detail Publication. Here is an example of pulp_file
+  introducing the `FilePublisher <https://github.com/pulp/pulp_file/pull/205>`_ as an example of
+  changes to match along with its `follow-on change <https://github.com/pulp/pulp_file/pull/215>`.
+
 0.1.0rc1
 ========
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 requirements = [
-    'pulpcore>=3.0.0rc1',
+    'pulpcore>=3.0.0rc2',
     'aiohttp',
     'aiofiles',
     'backoff',
@@ -14,7 +14,7 @@ setup(
     name='pulpcore-plugin',
     description='Pulp Plugin API',
     long_description=long_description,
-    version='0.1.0rc1',
+    version='0.1.0rc2',
     license='GPLv2+',
     packages=find_packages(exclude=['test']),
     author='Pulp Team',


### PR DESCRIPTION
This adds a release notes section which includes the up-to-date breaking
changes. It also version bumps this pacakge to 0.1.0rc2 and will depend
on pulpcore 3.0.0rc2.

[noissue]

