### PR TITLE
Problem: remote's proxy_url setting not being used during sync

### DIFF
--- a/CHANGES/5011.bugfix
+++ b/CHANGES/5011.bugfix
@@ -1,0 +1,1 @@
+Fixes use of the proxy URL when syncing from a remote.

--- a/pulpcore/plugin/download/http.py
+++ b/pulpcore/plugin/download/http.py
@@ -179,7 +179,7 @@ class HttpDownloader(BaseDownloader):
         Args:
             extra_data (dict): Extra data passed by the downloader.
         """
-        async with self.session.get(self.url) as response:
+        async with self.session.get(self.url, proxy=self.proxy) as response:
             response.raise_for_status()
             to_return = await self._handle_response(response)
             await response.release()


### PR DESCRIPTION
Solution: pass in the proxy url to the get() request

fixes: #5011
https://pulp.plan.io/issues/5011