### PR TITLE
Add validation exceptions to plugin API

### DIFF
--- a/CHANGES/5077.feature
+++ b/CHANGES/5077.feature
@@ -1,0 +1,2 @@
+The ``DigestValidationError`` and ``SizeValidationError`` are available in the
+``pulpcore.plugin.exceptions`` package.

--- a/pulpcore/plugin/exceptions.py
+++ b/pulpcore/plugin/exceptions.py
@@ -1,1 +1,1 @@
-from pulpcore.exceptions import PulpException  # noqa
+from pulpcore.exceptions import DigestValidationError, PulpException, SizeValidationError  # noqa


### PR DESCRIPTION
The `DigestValidationError` and `SizeValidationError` validation
exceptions were not available in the plugin API. Now they are available
in `pulpcore.plugin.exceptions` package.

https://pulp.plan.io/issues/5077
closes #5077

