### PR TITLE
Adds ``ContentGuard`` plugin writer docs

### DIFF
--- a/CHANGES/3972.doc
+++ b/CHANGES/3972.doc
@@ -1,0 +1,1 @@
+Adds a new page and various updates with ``ContentGuard`` documentation for plugin writers.

--- a/docs/plugin-writer/concepts/index.rst
+++ b/docs/plugin-writer/concepts/index.rst
@@ -11,11 +11,13 @@ the plugin_template, but if you are interested in the details of what it provide
 :ref:`plugin-django-application` for more information for how plugins are "discovered" and connected to
 the ``pulpcore`` Django app. Additional information is given as inline comments in the template.
 
+
 Plugin API Usage
 ----------------
 Plugin Applications interact with pulpcore with two high level interfaces, **subclassing** and
 adding **tasks**. Additionally, plugins that need to implement dynamic web APIs can
 optionally provide their own Django views. See our :ref:`live-apis` page for more information.
+
 
 .. _subclassing-general:
 
@@ -35,6 +37,7 @@ the box.
    subclassing/models
    subclassing/serializers
    subclassing/viewsets
+
 
 .. _writing-tasks:
 
@@ -65,6 +68,7 @@ Tasks are deployed from Views or Viewsets, please see :ref:`kick-off-tasks`.
    tasks/publish
    tasks/export
 
+
 Sync Pipeline
 -------------
 
@@ -72,3 +76,15 @@ Sync Pipeline
    :maxdepth: 2
 
    sync_pipeline/sync_pipeline
+
+
+Content Protection
+------------------
+
+Users can configure a ``ContentGuard`` to protect a ``Distribution`` on their own, but some plugins
+want to offer built-in content protection features. For example pulp_docker may only want a user to
+download docker images they have rights to based on some permissions system pulp_docker could
+provide.
+
+For more information see the :ref:`ContentGuard Usage by Plugin Writers
+<plugin-writers-use-content-protection>` documentation.

--- a/docs/reference/content-protection.rst
+++ b/docs/reference/content-protection.rst
@@ -1,0 +1,90 @@
+.. _content-protection:
+
+Content Protection
+------------------
+
+By default, the Content app will serve all content, but some deployments want to only serve content
+to some users and not others. For example pulp_rpm only wants to give rpms to users who have valid
+certificates declaring their paid access to content. To allow total customization of how content is
+protected, A plugin writer can define a ``ContentGuard``.
+
+
+Defining a ContentGuard
+^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``ContentGuard`` is a Master/Detail object provided at
+``from pulpcore.plugin.models import ContentGuard``, which provides `these base fields <https://
+github.com/pulp/pulpcore/blob/master/pulpcore/app/models/publication.py#L192-L202>`_.
+
+In your plugin code, subclass ``ContentGuard`` and optionally add additional fields as necessary to
+perform the authentication and authorization. As with all Master/Detail objects a ``TYPE`` class
+attribute is needed which is then used in the URL. For ``ContentGuard`` detail objects the URL
+structure is::
+
+    ``/pulp/api/v3/contentguards/<plugin_name>/<TYPE>/``
+
+
+.. note::
+
+   The `pulp-certguard <https://pulp-certguard.readthedocs.io/en/latest/>`_ plugin ships various
+   ``ContentGuard`` types for users and plugin writers to use together. Plugins can ship their own
+   content guards too, but look at the existing ones first.
+
+
+Simple Example
+^^^^^^^^^^^^^^
+
+Here's a trivial example where the client needs to send a header named SECRET_STRING and if its
+value matches a recorded value for that ContentGuard instance, give the content to the user. The
+secret both authenticates the user and authorizes them for this Content.
+
+.. code-block:: python
+
+   from django.db import models
+   from pulpcore.plugin.models import ContentGuard
+
+   class SecretStringContentGuard(ContentGuard):
+
+       TYPE = 'secret_string'
+
+       secret_string = models.FileField(max_length=255)
+
+       def permit(self, request):
+            """
+
+            Authorize the specified web request.
+
+            Args:
+                request (aiohttp.web.Request): A request for a published file.
+
+            Raises:
+                PermissionError: When the request cannot be authorized.
+            """
+            ca = self.ca_certificate.read()
+            validator = Validator(ca.decode('utf8'))
+            validator(request)
+
+
+End-User use of ContentGuard
+############################
+
+Users create an instance of a ``SecretStringContentGuard`` and give it a secret string with
+``httpie``::
+
+   http POST http://localhost:24817/pulp/api/v3/contentguards/<plugin_name>/secret_string/ \
+                 secret_string='2xlSFgJwOhbLrtIlmYszqHQy7ivzdQo9'
+
+
+Then the user can protect one or more Distributions by specifying ``content_guard``. See the
+`ContentGuard creation API <https://docs.pulpproject.org/en/3.0/nightly/restapi.html#operation/
+distributions_file_file_create>`_ for more information.
+
+
+.. _plugin-writers-use-content-protection:
+
+Plugin Writer use of ContentGuard
+#################################
+
+Plugin writers can also programatically create detail ``ContentGuard`` instances and have the
+plugin's detail Distribution they define force its use. This allows plugin writers to offer
+content protection features to users with fewer user required steps.

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -13,4 +13,4 @@ This section includes in-depth material that is topic specific.
    live-api
    on-demand-support
    releasing
-
+   content-protection


### PR DESCRIPTION
The ``ContentGuard`` was usable in the plugin API before, but there were
not very good docs on it. This explains to plugin writers how to define
and use detail ``ContentGuard`` objects.

https://pulp.plan.io/issues/3972
closes #3972

