### PR TITLE
Modularity sync

### DIFF
--- a/pulpcore/plugin/stages/artifact_stages.py
+++ b/pulpcore/plugin/stages/artifact_stages.py
@@ -232,7 +232,8 @@ class RemoteArtifactSaver(Stage):
         remotes_present = set()
         for d_content in batch:
             for d_artifact in d_content.d_artifacts:
-                remotes_present.add(d_artifact.remote)
+                if d_artifact.remote:
+                    remotes_present.add(d_artifact.remote)
 
         prefetch_related_objects(
             [d_c.content for d_c in batch],
@@ -262,8 +263,9 @@ class RemoteArtifactSaver(Stage):
                     if remote_artifact.remote_id == d_artifact.remote.pk:
                         break
                 else:
-                    remote_artifact = self._create_remote_artifact(d_artifact, content_artifact)
-                    needed_ras.append(remote_artifact)
+                    if d_artifact.remote:
+                        remote_artifact = self._create_remote_artifact(d_artifact, content_artifact)
+                        needed_ras.append(remote_artifact)
         return needed_ras
 
     @staticmethod


### PR DESCRIPTION
adds conditional to skip artifactdownload and artifactremote stages if not needed for declared artifact by checking if declarative artifact has remote

Required PR: pulp/pulp_rpm#1434

re #5172
https://pulp.plan.io/issues/5172
