### PR TITLE
Skip downloading DeclarativeArtifacts if a file is already present

### DIFF
--- a/CHANGES/5413.feature
+++ b/CHANGES/5413.feature
@@ -1,0 +1,1 @@
+DeclarativeArtifacts can have an Artifact without a RemoteArtifact.

--- a/pulpcore/plugin/stages/artifact_stages.py
+++ b/pulpcore/plugin/stages/artifact_stages.py
@@ -232,7 +232,8 @@ class RemoteArtifactSaver(Stage):
         remotes_present = set()
         for d_content in batch:
             for d_artifact in d_content.d_artifacts:
-                remotes_present.add(d_artifact.remote)
+                if d_artifact.remote:
+                    remotes_present.add(d_artifact.remote)
 
         prefetch_related_objects(
             [d_c.content for d_c in batch],
@@ -262,8 +263,9 @@ class RemoteArtifactSaver(Stage):
                     if remote_artifact.remote_id == d_artifact.remote.pk:
                         break
                 else:
-                    remote_artifact = self._create_remote_artifact(d_artifact, content_artifact)
-                    needed_ras.append(remote_artifact)
+                    if d_artifact.remote:
+                        remote_artifact = self._create_remote_artifact(d_artifact, content_artifact)
+                        needed_ras.append(remote_artifact)
         return needed_ras
 
     @staticmethod

--- a/pulpcore/plugin/stages/artifact_stages.py
+++ b/pulpcore/plugin/stages/artifact_stages.py
@@ -149,7 +149,9 @@ class ArtifactDownloader(Stage):
         """
         downloaders_for_content = [
             d_artifact.download() for d_artifact in d_content.d_artifacts
-            if d_artifact.artifact._state.adding and not d_artifact.deferred_download
+            if d_artifact.artifact._state.adding and
+            not d_artifact.deferred_download and
+            not d_artifact.artifact.file
         ]
         if downloaders_for_content:
             await asyncio.gather(*downloaders_for_content)


### PR DESCRIPTION
This patch introduces an additional check to the method that schedules Artifact
downloading. DeclarativeArtifacts that contain an Artifact that already has a file
are not scheduled for download.

This patch also makes the remote required for the DeclarativeArtifact unless the Artifact
already has a file associated with it.
    
closes: #5413
https://pulp.plan.io/issues/5413
    
re: #5172
https://pulp.plan.io/issues/5172
