### PR TITLE
Remove JSONField from public API

### DIFF
--- a/CHANGES/5465.removal
+++ b/CHANGES/5465.removal
@@ -1,0 +1,1 @@
+Remove custom JSONField implementation from public API

--- a/pulpcore/plugin/fields.py
+++ b/pulpcore/plugin/fields.py
@@ -1,1 +1,0 @@
-from pulpcore.app.fields import JSONField  # noqa


### PR DESCRIPTION
We're using Django's from now on, not our own.

re: 5465
https://pulp.plan.io/issues/5465

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/en/3.0/nightly/contributing/pull-request-walkthrough.html
