### PR TITLE
Add release note for changes in pulpcore

### DIFF
--- a/CHANGES/5008.feature
+++ b/CHANGES/5008.feature
@@ -1,0 +1,4 @@
+Add new `repo_key` class attribute to `Content` which defaults to an empty tuple. Subclasses should
+use `repo_key` to specify the names of fields, which together should be unique per Repository.
+Anytime `RepositoryVersion.add_content()` is called, it now automatically removes content that
+matches the `repo_key`.


### PR DESCRIPTION
The feature is actually in pulpcore's code, but the release note needs
to be in this package, which imports it.

Related PR:  https://github.com/pulp/pulpcore/pull/331

https://pulp.plan.io/issues/5008
closes #5008

